### PR TITLE
유저 API N+1 쿼리 개선

### DIFF
--- a/waffledotcom/src/apps/user/repositories.py
+++ b/waffledotcom/src/apps/user/repositories.py
@@ -1,5 +1,5 @@
 from fastapi import Depends
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from waffledotcom.src.apps.user.models import User
 from waffledotcom.src.database.connection import Transaction, get_db_session
@@ -15,7 +15,7 @@ class UserRepository:
         self.transaction = transaction
 
     def get_users(self) -> list[User]:
-        return self.session.query(User).all()
+        return self.session.query(User).options(joinedload(User.positions)).all()
 
     def get_user_by_id(self, user_id: int) -> User | None:
         return self.session.query(User).filter(User.id == user_id).first()


### PR DESCRIPTION
1. Session 생성 시 간헐적으로 DB 와 통신에 실패하는 케이스를 대응하기 위해 retry 로직 추가
  2. 각 retry 마다 비동기적으로 대기하는 로직을 위해 get_db_session 을 async generator 로 변경
3. UserRepository 의 get_users 에서 N+1 쿼리가 발생하는 문제를 개선